### PR TITLE
Naprawa liczenia czasu od ostaniej zmiany statusu w wersji Websocket

### DIFF
--- a/src/main/java/com/github/britter/springbootherokudemo/endpoint/RoomRestController.java
+++ b/src/main/java/com/github/britter/springbootherokudemo/endpoint/RoomRestController.java
@@ -29,7 +29,6 @@ public class RoomRestController {
     @Autowired
     private RoomService roomService;
 
-
     @RequestMapping(value = "", method = RequestMethod.GET, produces = {"application/json"})
     ResponseEntity<List<RoomDTO>> getAllRoomsAvailibility() {
         List<RoomDTO> allRooms = roomRepository.findAll()
@@ -49,7 +48,7 @@ public class RoomRestController {
         return ResponseEntity.ok(mapper.map(room));
     }
 
-    @RequestMapping(value = "/{roomId}", method = { RequestMethod.POST, RequestMethod.PUT }, consumes = {"text/plain"})
+    @RequestMapping(value = "/{roomId}", method = {RequestMethod.POST, RequestMethod.PUT}, consumes = {"text/plain"})
     ResponseEntity<?> updateRoomAvailability(@PathVariable Long roomId, @RequestBody String occupied) {
         Room room = roomRepository.getOne(roomId);
 
@@ -61,11 +60,16 @@ public class RoomRestController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
 
-        roomService.updateRoomOccupied(room, occupied);
-        webSocketService.sendStatusUpdateNotificationToAllRegisteredClients();
+        final Boolean newOccupiedStatus = Boolean.valueOf(occupied);
+
+        if (roomService.hasRoomOccupiedStatusChanged(room, newOccupiedStatus)) {
+            roomService.updateRoomOccupied(room, newOccupiedStatus);
+            webSocketService.sendStatusUpdateNotificationToAllRegisteredClients();
+        } else {
+            roomService.updateOnlyLastUpdateDate(room);
+        }
 
         return ResponseEntity.ok(null);
     }
-
 
 }

--- a/src/main/java/com/github/britter/springbootherokudemo/entity/db/Room.java
+++ b/src/main/java/com/github/britter/springbootherokudemo/entity/db/Room.java
@@ -21,7 +21,7 @@ public class Room {
 
     private Date lastUpdateDate;
 
-    private Date lastOccupiedUpdateDate;
+    private Date lastOccupiedStatusChangeDate;
 
     public Room() {
     }

--- a/src/main/java/com/github/britter/springbootherokudemo/mapper/RoomToRoomDTORestMapper.java
+++ b/src/main/java/com/github/britter/springbootherokudemo/mapper/RoomToRoomDTORestMapper.java
@@ -24,13 +24,13 @@ public class RoomToRoomDTORestMapper extends RoomToRoomDTOMapper {
             dto.setOccupied(null);
         }
 
-        Duration duration = calculateLastOccupiedUpdateDuration(room.getLastOccupiedUpdateDate());
+        Duration duration = calculateDurationSinceLastOccupiedStatusChange(room.getLastOccupiedStatusChangeDate());
         dto.setStatus(massages.get("status.occupation.withTime." + String.valueOf(dto.getOccupied()),
                 new Object[]{duration.getHours(), duration.getMinutes(), duration.getSeconds()}));
     }
 
-    private Duration calculateLastOccupiedUpdateDuration(Date lastOccupiedUpdateDate) {
-        long diff = new Date().getTime() - Optional.ofNullable(lastOccupiedUpdateDate).orElse(new Date()).getTime();
+    private Duration calculateDurationSinceLastOccupiedStatusChange(Date lastOccupiedStatusChangeDate) {
+        long diff = new Date().getTime() - Optional.ofNullable(lastOccupiedStatusChangeDate).orElse(new Date()).getTime();
         long hours = TimeUnit.MILLISECONDS.toHours(diff);
         long minutes = TimeUnit.MILLISECONDS.toMinutes(diff) - (TimeUnit.MILLISECONDS.toHours(diff) * 60);
         long seconds = TimeUnit.MILLISECONDS.toSeconds(diff) - (TimeUnit.MILLISECONDS.toMinutes(diff) * 60);

--- a/src/main/java/com/github/britter/springbootherokudemo/service/RoomService.java
+++ b/src/main/java/com/github/britter/springbootherokudemo/service/RoomService.java
@@ -2,7 +2,6 @@ package com.github.britter.springbootherokudemo.service;
 
 import com.github.britter.springbootherokudemo.entity.db.*;
 import com.github.britter.springbootherokudemo.repository.*;
-import com.github.britter.springbootherokudemo.util.*;
 import org.springframework.beans.factory.annotation.*;
 import org.springframework.stereotype.*;
 
@@ -13,17 +12,20 @@ public class RoomService {
     @Autowired
     private RoomRepository roomRepository;
 
-    public void updateRoomOccupied(Room room, String occupied){
-        final Boolean lastOccupied = room.getOccupied();
-        final Date lastUpdateDate = room.getLastUpdateDate();
-        final Boolean currentOccupied = Boolean.valueOf(occupied);
-
-        if (!currentOccupied.equals(lastOccupied) || DateTimeoutChecker.dateTimeout(lastUpdateDate)) {
-            room.setLastOccupiedUpdateDate(new Date());
-        }
-        room.setOccupied(currentOccupied);
+    public void updateRoomOccupied(Room room, Boolean newOccupiedStatus) {
+        room.setOccupied(newOccupiedStatus);
+        room.setLastOccupiedStatusChangeDate(new Date());
         room.setLastUpdateDate(new Date());
 
         roomRepository.save(room);
+    }
+
+    public void updateOnlyLastUpdateDate(Room room) {
+        room.setLastUpdateDate(new Date());
+        roomRepository.save(room);
+    }
+
+    public boolean hasRoomOccupiedStatusChanged(Room room, Boolean newOccupiedStatus) {
+        return !newOccupiedStatus.equals(room.getOccupied());
     }
 }

--- a/src/main/resources/rooms.json
+++ b/src/main/resources/rooms.json
@@ -4,7 +4,7 @@
       "name": "Łazienka parter",
       "occupied":null,
       "lastUpdateDate":null,
-      "lastOccupiedUpdateDate":null,
+      "lastOccupiedStatusChangeDate":null,
       "token":"123"
     },
     {
@@ -12,7 +12,7 @@
       "name": "Łazienka 1 piętro",
       "occupied":null,
       "lastUpdateDate":null,
-      "lastOccupiedUpdateDate":null,
+      "lastOccupiedStatusChangeDate":null,
       "token":"123"
     }
   ]


### PR DESCRIPTION
- Powiadomienie o zmianie statusu leciało przy każdym requeście od
Rasberry, co w efekcie zerowało licznik co 30s.
 Teraz najpierw sprawdzamy, czy status uległ zmianie i jeśli tak
 to dopiero aktualizujemy status pokoju oraz wysyłamy powiadomienie,

 - Zmieniono nazwę pola lastOccupiedUpdateDate na
 lastOccupiedStatusChangeDate ponieważ trochę czasu mi zajęło
 ogarnięcie jaka jest różnica między tym polem, a polem
 lastUpdateDate.

 - Wywaliłem z metody updateRoomOccupied sprawdzanie timeoutu.
 Może niesłusznie, ale nie do końca rozumiem po co przy wiadomości
 od raspberry był on sprawdzany.

Ogólnie przemyślałbym logikę sprawdzania time'outu bo w tej chwili jest on sprawdzany 
podczas mapowania i ustawiany na obiekcie dto, a nie encji bazodanowej. Możnaby np. utworzyć scheduler, który by co jakiś czas sprawdzał timeout i ustawiał go na właściwym obiekcie bazodanowym, a nie dto.

#14 